### PR TITLE
no x flag for logr2ram.server

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 if [ `id -u` -eq 0 ]
 then
   cp log2ram.service /etc/systemd/system/log2ram.service
-  chmod 644 /etc/systemd/system/log2ram.server
+  chmod 644 /etc/systemd/system/log2ram.service
   cp log2ram /usr/local/bin/log2ram
   chmod a+x /usr/local/bin/log2ram
   systemctl enable log2ram

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,8 @@
 if [ `id -u` -eq 0 ]
 then
   cp log2ram.service /etc/systemd/system/log2ram.service
-    cp log2ram /usr/local/bin/log2ram
+  chmod 644 /etc/systemd/system/log2ram.server
+  cp log2ram /usr/local/bin/log2ram
   chmod a+x /usr/local/bin/log2ram
   systemctl enable log2ram
   

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,7 @@
 if [ `id -u` -eq 0 ]
 then
   cp log2ram.service /etc/systemd/system/log2ram.service
-  chmod a+x /etc/systemd/system/log2ram.service
-  cp log2ram /usr/local/bin/log2ram
+    cp log2ram /usr/local/bin/log2ram
   chmod a+x /usr/local/bin/log2ram
   systemctl enable log2ram
   


### PR DESCRIPTION
For me, the x flag on that file produces the following warning each boot:

Aug 02 09:53:12 machine systemd[1]: Configuration file /etc/systemd/system/log2ram.service is marked executable. Please remove executable permission bits. Proceeding anyway.

Without the x flag, everything works fine here. Not sure if your version of systemd has different requirements. If so, feel free to ignore. :-)