### PR TITLE
Write sync status to HDD_LOG/log2ram.log.

### DIFF
--- a/log2ram
+++ b/log2ram
@@ -2,8 +2,17 @@
 
 HDD_LOG=/var/log.hdd/
 RAM_LOG=/var/log/
+LOG2RAM_LOG="${HDD_LOG}log2ram.log"
 SIZE=40M
 USE_RSYNC=false
+
+sync () {
+    if [ "$USE_RSYNC" = true ]; then
+        rsync -aXWv --delete --links $HDD_LOG $RAM_LOG 2>&1 | tee -a $LOG2RAM_LOG
+    else
+        cp -rfup $HDD_LOG -T $RAM_LOG 2>&1 | tee -a $LOG2RAM_LOG
+    fi
+}
 
 case "$1" in
   start)
@@ -11,28 +20,16 @@ case "$1" in
       mount --bind $RAM_LOG $HDD_LOG
       mount --make-private $HDD_LOG
       mount -t tmpfs -o nosuid,noexec,nodev,mode=0755,size=$SIZE log2ram $RAM_LOG
-      if [ "$USE_RSYNC" = true ]; then
-          rsync -aXWv --delete --links $HDD_LOG $RAM_LOG
-      else
-          cp -rfup $HDD_LOG -T $RAM_LOG
-      fi
+      sync
       ;;
 
   stop)
-      if [ "$USE_RSYNC" = true ]; then
-          rsync -aXWv --delete --links $RAM_LOG $HDD_LOG
-      else
-          cp -rfup $RAM_LOG -T $HDD_LOG
-      fi
+      sync
       umount -l $RAM_LOG
       umount -l $HDD_LOG
       ;;
 
   write)
-      if [ "$USE_RSYNC" = true ]; then
-          rsync -aXWv --delete --links $RAM_LOG $HDD_LOG
-      else
-          cp -rfup $RAM_LOG -T $HDD_LOG
-      fi
+      sync
       ;;
 esac

--- a/log2ram
+++ b/log2ram
@@ -5,15 +5,16 @@ RAM_LOG=/var/log/
 LOG2RAM_LOG="${HDD_LOG}log2ram.log"
 SIZE=40M
 USE_RSYNC=false
+LOG_OUTPUT="tee -a $LOG2RAM_LOG"
 
 syncToDisk () {
     [ -d $HDD_LOG ] || echo "ERROR: $HDD_LOG doesn't exist!  Can't sync."
     [ -d $HDD_LOG ] || exit 1
 
     if [ "$USE_RSYNC" = true ]; then
-        rsync -aXWv --delete --links $RAM_LOG $HDD_LOG 2>&1 | tee -a $LOG2RAM_LOG
+        rsync -aXWv --delete --exclude log2ram.log --links $RAM_LOG $HDD_LOG 2>&1 | $LOG_OUTPUT
     else
-        cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | tee -a $LOG2RAM_LOG
+        cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | $LOG_OUTPUT
     fi
 }
 
@@ -22,9 +23,9 @@ syncFromDisk () {
     [ -d $HDD_LOG ] || exit 1
 
     if [ "$USE_RSYNC" = true ]; then
-        rsync -aXWv --delete --links $HDD_LOG $RAM_LOG 2>&1 | tee -a $LOG2RAM_LOG
+        rsync -aXWv --delete --exclude log2ram.log --links $HDD_LOG $RAM_LOG 2>&1 | $LOG_OUTPUT
     else
-        cp -rfup $HDD_LOG -T $RAM_LOG 2>&1 | tee -a $LOG2RAM_LOG
+        cp -rfup $HDD_LOG -T $RAM_LOG 2>&1 | $LOG_OUTPUT
     fi
 }
 

--- a/log2ram
+++ b/log2ram
@@ -6,7 +6,21 @@ LOG2RAM_LOG="${HDD_LOG}log2ram.log"
 SIZE=40M
 USE_RSYNC=false
 
-sync () {
+syncToDisk () {
+    [ -d $HDD_LOG ] || echo "ERROR: $HDD_LOG doesn't exist!  Can't sync."
+    [ -d $HDD_LOG ] || exit 1
+
+    if [ "$USE_RSYNC" = true ]; then
+        rsync -aXWv --delete --links $RAM_LOG $HDD_LOG 2>&1 | tee -a $LOG2RAM_LOG
+    else
+        cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | tee -a $LOG2RAM_LOG
+    fi
+}
+
+syncFromDisk () {
+    [ -d $HDD_LOG ] || echo "ERROR: $HDD_LOG doesn't exist!  Can't sync."
+    [ -d $HDD_LOG ] || exit 1
+
     if [ "$USE_RSYNC" = true ]; then
         rsync -aXWv --delete --links $HDD_LOG $RAM_LOG 2>&1 | tee -a $LOG2RAM_LOG
     else
@@ -14,22 +28,23 @@ sync () {
     fi
 }
 
+
 case "$1" in
   start)
       [ -d $HDD_LOG ] || mkdir $HDD_LOG
       mount --bind $RAM_LOG $HDD_LOG
       mount --make-private $HDD_LOG
       mount -t tmpfs -o nosuid,noexec,nodev,mode=0755,size=$SIZE log2ram $RAM_LOG
-      sync
+      syncFromDisk
       ;;
 
   stop)
-      sync
+      syncToDisk
       umount -l $RAM_LOG
       umount -l $HDD_LOG
       ;;
 
   write)
-      sync
+      syncToDisk
       ;;
 esac


### PR DESCRIPTION
This pull request resolves azlug/log2ram's issue #6.

- Store sync status directly in the HDD log, to make sure we know
  about it if something fails.  This won't help if the HDD_LOG
  variable is borked, but it'll help with everything else.

- Made sync a function to avoid repeating five lines three times.

- log2ram now requires (cp or rsync) and tee, mount, umount.