### PR TITLE
Sync the ramlog back to disk, hourly.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,10 @@ then
   cp log2ram /usr/local/bin/log2ram
   chmod a+x /usr/local/bin/log2ram
   systemctl enable log2ram
-  
+  cp log2ram.hourly /etc/cron.hourly/log2ram
+  chmod +x /etc/cron.hourly/log2ram
+
   echo "Reboot to activate log2ram"
-else 
+else
   echo "You need to be ROOT (sudo can be used)"
 fi

--- a/log2ram
+++ b/log2ram
@@ -7,6 +7,9 @@ SIZE=40M
 USE_RSYNC=false
 
 sync () {
+    [ -d $HDD_LOG ] || echo "ERROR: $HDD_LOG doesn't exist!  Can't sync."
+    [ -d $HDD_LOG ] || exit 1
+
     if [ "$USE_RSYNC" = true ]; then
         rsync -aXWv --delete --links $HDD_LOG $RAM_LOG 2>&1 | tee -a $LOG2RAM_LOG
     else

--- a/log2ram
+++ b/log2ram
@@ -2,8 +2,17 @@
 
 HDD_LOG=/var/log.hdd/
 RAM_LOG=/var/log/
+LOG2RAM_LOG="${HDD_LOG}log2ram.log"
 SIZE=40M
 USE_RSYNC=false
+
+sync () {
+    if [ "$USE_RSYNC" = true ]; then
+        rsync -aXWv --delete --links $HDD_LOG $RAM_LOG 2>&1 | tee -a $LOG2RAM_LOG
+    else
+        cp -rfup $HDD_LOG -T $RAM_LOG 2>&1 | tee -a $LOG2RAM_LOG
+    fi
+}
 
 case "$1" in
   start)
@@ -11,28 +20,16 @@ case "$1" in
       mount --bind $RAM_LOG $HDD_LOG
       mount --make-private $HDD_LOG
       mount -t tmpfs -o nosuid,noexec,nodev,mode=0755,size=$SIZE log2ram $RAM_LOG
-      if [ "$USE_RSYNC" = true ]; then
-          rsync -aXWv --delete --links $HDD_LOG $RAM_LOG
-      else
-          cp -rfup $HDD_LOG -T $RAM_LOG
-      fi
+      sync
       ;;
 
   stop)
-      if [ "$USE_RSYNC" = true ]; then
-          rsync -aXWv --delete --links $RAM_LOG $HDD_LOG
-      else
-          cp -rfup $RAM_LOG -T $HDD_LOG
-      fi
+      sync
       umount -l $RAM_LOG
       umount -l $HDD_LOG
       ;;
 
   write)
-      if [ "$USE_RSYNC" = true ]; then
-          rsync -aXWv --delete --links $RAM_LOG $HDD_LOG
-      else
-          cp -rfup $RAM_LOG -T $HDD_LOG
-      fi
+      sync
       ;;
 esac

--- a/log2ram
+++ b/log2ram
@@ -5,15 +5,16 @@ RAM_LOG=/var/log/
 LOG2RAM_LOG="${HDD_LOG}log2ram.log"
 SIZE=40M
 USE_RSYNC=false
+LOG_OUTPUT="tee -a $LOG2RAM_LOG"
 
 syncToDisk () {
     [ -d $HDD_LOG ] || echo "ERROR: $HDD_LOG doesn't exist!  Can't sync."
     [ -d $HDD_LOG ] || exit 1
 
     if [ "$USE_RSYNC" = true ]; then
-        rsync -aXWv --delete --links $RAM_LOG $HDD_LOG 2>&1 | tee -a $LOG2RAM_LOG
+        rsync -aXWv --delete --exclude log2ram.log --links $RAM_LOG $HDD_LOG 2>&1 | $LOG_OUTPUT
     else
-        cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | tee -a $LOG2RAM_LOG
+        cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | $LOG_OUTPUT
     fi
 }
 
@@ -22,9 +23,9 @@ syncFromDisk () {
     [ -d $HDD_LOG ] || exit 1
 
     if [ "$USE_RSYNC" = true ]; then
-        rsync -aXWv --delete --links $HDD_LOG $RAM_LOG 2>&1 | tee -a $LOG2RAM_LOG
+        rsync -aXWv --delete --exclude log2ram.log --links $HDD_LOG $RAM_LOG 2>&1 | $LOG_OUTPUT
     else
-        cp -rfup $HDD_LOG -T $RAM_LOG 2>&1 | tee -a $LOG2RAM_LOG
+        cp -rfup $HDD_LOG -T $RAM_LOG 2>&1 | $LOG_OUTPUT
     fi
 }
 

--- a/log2ram
+++ b/log2ram
@@ -6,7 +6,18 @@ LOG2RAM_LOG="${HDD_LOG}log2ram.log"
 SIZE=40M
 USE_RSYNC=false
 
-sync () {
+syncToDisk () {
+    [ -d $HDD_LOG ] || echo "ERROR: $HDD_LOG doesn't exist!  Can't sync."
+    [ -d $HDD_LOG ] || exit 1
+
+    if [ "$USE_RSYNC" = true ]; then
+        rsync -aXWv --delete --links $RAM_LOG $HDD_LOG 2>&1 | tee -a $LOG2RAM_LOG
+    else
+        cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | tee -a $LOG2RAM_LOG
+    fi
+}
+
+syncFromDisk () {
     [ -d $HDD_LOG ] || echo "ERROR: $HDD_LOG doesn't exist!  Can't sync."
     [ -d $HDD_LOG ] || exit 1
 
@@ -17,22 +28,23 @@ sync () {
     fi
 }
 
+
 case "$1" in
   start)
       [ -d $HDD_LOG ] || mkdir $HDD_LOG
       mount --bind $RAM_LOG $HDD_LOG
       mount --make-private $HDD_LOG
       mount -t tmpfs -o nosuid,noexec,nodev,mode=0755,size=$SIZE log2ram $RAM_LOG
-      sync
+      syncFromDisk
       ;;
 
   stop)
-      sync
+      syncToDisk
       umount -l $RAM_LOG
       umount -l $HDD_LOG
       ;;
 
   write)
-      sync
+      syncToDisk
       ;;
 esac

--- a/log2ram.hourly
+++ b/log2ram.hourly
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+/usr/local/bin/log2ram write


### PR DESCRIPTION
Since computers crash occasionally, it's probably a good idea to sync
the ramlog back to disk on occasion.  This pull request adds a cron
script to sync the ram log to disk every hour.

Sure, it's more disk activity than only syncing on power off but, for
systems that have days or weeks of uptime, it'll more reliable
overall.  For example, I always suspend my laptop, it only gets turned
off when it crashes, which would mean losing weeks of logfiles.

**Note:** This should be merged after pull request #7.