### PR TITLE
Update service dependencies to start on early boot

### DIFF
--- a/log2ram.service
+++ b/log2ram.service
@@ -1,6 +1,11 @@
 [Unit]
 Description=Log2Ram
-Before=syslog.target mysql.service fail2ban.service nginx.service rsyslog.service
+DefaultDependencies=no
+Before=rsyslog.service syslog.target systemd-journald.service sysinit.target shutdown.target
+After=local-fs.target
+Conflicts=shutdown.target
+RequiresMountsFor=/var/log /var/log.hdd
+IgnoreOnIsolate=yes
 
 [Service]
 Type=oneshot
@@ -10,4 +15,4 @@ ExecReload= /usr/local/bin/log2ram write
 RemainAfterExit=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target


### PR DESCRIPTION
As requested here: https://github.com/igorpecovnik/lib/commit/9f4a1cb0402e79feb3eec849c6455cc0272e6565

This changes log2ram dependencies to start as early as possible, before other
services that may require access to /var/log, including rsyslog and
systemd-journald.

Additional dependencies on shutdown.target are required to ensure that
the service will be stopped at shutdown/reboot when DefaultDependencies
is set to "no" [[1]].

RequiresMountsFor declares dependency on /var mount when it is a mount point.

IgnoreOnIsolate prevents stopping the service when isolating another unit.

[1]: https://www.freedesktop.org/software/systemd/man/systemd.service.html