### PR TITLE
Added check of tmpfs size before syncing HDD to RAM.

### DIFF
--- a/log2ram
+++ b/log2ram
@@ -28,6 +28,11 @@ syncToDisk () {
 syncFromDisk () {
     isSafe
 
+    if [ ! -z `du -sh -t $SIZE $HDD_LOG | cut -f1` ]; then
+        echo "ERROR: RAM disk too small. Can't sync."
+        exit 1
+    fi
+
     if [ "$USE_RSYNC" = true ]; then
         rsync -aXWv --delete --exclude log2ram.log --links $HDD_LOG $RAM_LOG 2>&1 | $LOG_OUTPUT
     else


### PR DESCRIPTION
I noticed that one of my VMs running log2ram was hanging in boot when trying to start log2ram. I figured that this might have been related to the HDD log dir outgrowing tmpfs and then added a size check in syncFromDisk.

Creating a pull request for it in case it should be of use for anyone else.