### PR TITLE
unmount tmpfs if RAM too small to prevent corruption of logdir

### DIFF
--- a/log2ram
+++ b/log2ram
@@ -27,6 +27,8 @@ syncFromDisk () {
 
     if [ ! -z `du -sh -t $SIZE $HDD_LOG | cut -f1` ]; then
         echo "ERROR: RAM disk too small. Can't sync."
+        umount -l $RAM_LOG
+        umount -l $HDD_LOG
         exit 1
     fi
 


### PR DESCRIPTION
Previously, log2ram just exited with error code 1 when the tmpfs was too small during syncFromDisk() at startup. That left, however, the mounts in place and therefore could lead to loss of data. New version removes the mounts upon this error.
