### PR TITLE
Added logrotate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ mount
 
 If you have issue with apache2 , you can try to add `apache2.service` next to other services on the `Before` parameter into /etc/systemd/system/log2ram.service it will solve the pb
 
-The log for log2ram will be write here : `/var/hdd.log/log2ram.log`
+The log for log2ram will be write here : `/var/log/log2ram.log`
 
 ###### Now, muffins for everyone !
 

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,8 @@ then
   systemctl enable log2ram
   cp log2ram.hourly /etc/cron.hourly/log2ram
   chmod +x /etc/cron.hourly/log2ram
+  cp log2ram.logrotate /etc/logrotate.d/log2ram
+  chmod 644 /etc/logrotate.d/log2ram
 
   # Remove a previous log2ram version
   if [ -d /var/log.hdd]; then

--- a/log2ram
+++ b/log2ram
@@ -51,10 +51,6 @@ wait_for () {
 }
 
 case "$1" in
-  rotate)
-      rm -f $LOG2RAM_LOG
-      ;;
-
   start)
       [ -d $HDD_LOG/ ] || mkdir $HDD_LOG/
       mount --bind $RAM_LOG/ $HDD_LOG/
@@ -76,7 +72,7 @@ case "$1" in
       ;;
 
   *)
-      echo "Usage: log2ram {clean-rotate|rotate|start|stop|write}" >&2
+      echo "Usage: log2ram {start|stop|write}" >&2
       exit 1
       ;;
 esac

--- a/log2ram
+++ b/log2ram
@@ -6,6 +6,7 @@ HDD_LOG=/var/hdd.log
 RAM_LOG=/var/log
 
 LOG_NAME="log2ram.log"
+LOGROTATE_PATTERN="${LOG_NAME}*"
 LOG2RAM_LOG="${HDD_LOG}/${LOG_NAME}"
 LOG_OUTPUT="tee -a $LOG2RAM_LOG"
 
@@ -18,7 +19,7 @@ syncToDisk () {
     isSafe
 
     if [ "$USE_RSYNC" = true ]; then
-        rsync -aXWv --delete --exclude $LOG_NAME --links $RAM_LOG/ $HDD_LOG/ 2>&1 | $LOG_OUTPUT
+        rsync -aXWv --delete --exclude $LOGROTATE_PATTERN --links $RAM_LOG/ $HDD_LOG/ 2>&1 | $LOG_OUTPUT
     else
         cp -rfup $RAM_LOG/ -T $HDD_LOG/ 2>&1 | $LOG_OUTPUT
     fi
@@ -38,7 +39,7 @@ syncFromDisk () {
     fi
 
     if [ "$USE_RSYNC" = true ]; then
-        rsync -aXWv --delete --exclude $LOG_NAME --links $HDD_LOG/ $RAM_LOG/ 2>&1 | $LOG_OUTPUT
+        rsync -aXWv --delete --exclude $LOGROTATE_PATTERN --links $HDD_LOG/ $RAM_LOG/ 2>&1 | $LOG_OUTPUT
     else
         cp -rfup $HDD_LOG/ -T $RAM_LOG/ 2>&1 | $LOG_OUTPUT
     fi
@@ -51,12 +52,20 @@ wait_for () {
 }
 
 case "$1" in
+  clean-rotate)
+      rm -f $HDD_LOG/$LOGROTATE_PATTERN
+      rm -f $RAM_LOG/$LOGROTATE_PATTERN
+      ;;
+
+  rotate)
+      rm -f $LOG2RAM_LOG
+      ;;
+
   start)
       [ -d $HDD_LOG/ ] || mkdir $HDD_LOG/
       mount --bind $RAM_LOG/ $HDD_LOG/
       mount --make-private $HDD_LOG/
       wait_for $HDD_LOG
-      rm -f $LOG2RAM_LOG
       mount -t tmpfs -o nosuid,noexec,nodev,mode=0755,size=$SIZE log2ram $RAM_LOG/
       wait_for $RAM_LOG
       syncFromDisk
@@ -73,7 +82,7 @@ case "$1" in
       ;;
 
   *)
-      echo "Usage: log2ram {start|stop|write}" >&2
+      echo "Usage: log2ram {clean-rotate|rotate|start|stop|write}" >&2
       exit 1
       ;;
 esac

--- a/log2ram
+++ b/log2ram
@@ -6,8 +6,7 @@ HDD_LOG=/var/hdd.log
 RAM_LOG=/var/log
 
 LOG_NAME="log2ram.log"
-LOGROTATE_PATTERN="${LOG_NAME}*"
-LOG2RAM_LOG="${HDD_LOG}/${LOG_NAME}"
+LOG2RAM_LOG="${RAM_LOG}/${LOG_NAME}"
 LOG_OUTPUT="tee -a $LOG2RAM_LOG"
 
 isSafe () {
@@ -19,7 +18,7 @@ syncToDisk () {
     isSafe
 
     if [ "$USE_RSYNC" = true ]; then
-        rsync -aXWv --delete --exclude $LOGROTATE_PATTERN --links $RAM_LOG/ $HDD_LOG/ 2>&1 | $LOG_OUTPUT
+        rsync -aXWv --delete --links $RAM_LOG/ $HDD_LOG/ 2>&1 | $LOG_OUTPUT
     else
         cp -rfup $RAM_LOG/ -T $HDD_LOG/ 2>&1 | $LOG_OUTPUT
     fi
@@ -39,7 +38,7 @@ syncFromDisk () {
     fi
 
     if [ "$USE_RSYNC" = true ]; then
-        rsync -aXWv --delete --exclude $LOGROTATE_PATTERN --links $HDD_LOG/ $RAM_LOG/ 2>&1 | $LOG_OUTPUT
+        rsync -aXWv --delete --links $HDD_LOG/ $RAM_LOG/ 2>&1 | $LOG_OUTPUT
     else
         cp -rfup $HDD_LOG/ -T $RAM_LOG/ 2>&1 | $LOG_OUTPUT
     fi
@@ -52,11 +51,6 @@ wait_for () {
 }
 
 case "$1" in
-  clean-rotate)
-      rm -f $HDD_LOG/$LOGROTATE_PATTERN
-      rm -f $RAM_LOG/$LOGROTATE_PATTERN
-      ;;
-
   rotate)
       rm -f $LOG2RAM_LOG
       ;;

--- a/log2ram.logrotate
+++ b/log2ram.logrotate
@@ -1,0 +1,13 @@
+/var/hdd.log/log2ram.log
+{
+  rotate 7
+  daily
+  missingok
+  notifempty
+  delaycompress
+  compress
+  postrotate
+    log2ram rotate > /dev/null
+  endscript
+}
+

--- a/log2ram.logrotate
+++ b/log2ram.logrotate
@@ -6,8 +6,5 @@
   notifempty
   delaycompress
   compress
-  postrotate
-    log2ram rotate > /dev/null
-  endscript
 }
 

--- a/log2ram.logrotate
+++ b/log2ram.logrotate
@@ -1,4 +1,4 @@
-/var/hdd.log/log2ram.log
+/var/log/log2ram.log
 {
   rotate 7
   daily

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -8,6 +8,7 @@ then
   rm /usr/local/bin/log2ram
   rm /etc/log2ram.conf
   rm /etc/cron.hourly/log2ram
+  rm /etc/logrotate.d/log2ram
 
   if [ -d /var/hdd.log ]; then
     rm -r /var/hdd.log


### PR DESCRIPTION
Note that the "log2ram.log" is **no** longer automatically deleted at reboot/start.
After installing log2ram, you can force log2ram to delete the all rotation files: "log2ram.log", "log2ram.log.1", etc.

Call:

`log2ram clean-rotate`
 
**Tip:**
This can also be done right after the installation and _before_ the reboot.

Default rotation is daily for 7 days.