### PR TITLE
install: Fixing code typo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ then
   chmod +x /etc/cron.hourly/log2ram
 
   # Remove a previous log2ram version
-  if [ -d /var/log.hdd]; then
+  if [ -d /var/log.hdd ]; then
     rm -r /var/log.hdd
   fi
 


### PR DESCRIPTION
The last bracket shall not be glued to the directory.

The actual code is generating a runtime error like the following :
 erwan@raspberrypi:~/download/log2ram $ sudo ./install.sh
 Created symlink /etc/systemd/system/sysinit.target.wants/log2ram.service → /etc/systemd/system/log2ram.service.
 ./install.sh: 19: [: missing ]
 ##### Reboot to activate log2ram #####

This patch simply adds the missing space to make this script work.