### PR TITLE
add nginx.service

### DIFF
--- a/log2ram.service
+++ b/log2ram.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Log2Ram
 DefaultDependencies=no
-Before=basic.target rsyslog.service syslog.target systemd-journald.service sysinit.target shutdown.target apache2.service
+Before=basic.target rsyslog.service syslog.target systemd-journald.service sysinit.target shutdown.target apache2.service nginx.service
 After=local-fs.target
 Conflicts=shutdown.target reboot.target halt.target
 RequiresMountsFor=/var/log /var/hdd.log


### PR DESCRIPTION
from netcraft "Market share of active sites" as of 2017-12:

1. apache: 44% (and shrinking)
2. nginx: 21% (and growing)

Is this dependency actually being ignored when it doesn't exist?