### PR TITLE
Add option to truncate logs in memory

### DIFF
--- a/log2ram
+++ b/log2ram
@@ -20,7 +20,19 @@ syncToDisk () {
     if [ "$USE_RSYNC" = true ]; then
         rsync -aXWv --delete --links $RAM_LOG/ $HDD_LOG/ 2>&1 | $LOG_OUTPUT
     else
-        cp -rfup $RAM_LOG/ -T $HDD_LOG/ 2>&1 | $LOG_OUTPUT
+		if [ "$USE_PATCH" = true ]; then 
+			for entry in $(ls -t $RAM_LOG/)
+			do			
+				if [ ! -f "$HDD_LOG/$entry" ]; then
+					cat $RAM_LOG/$entry >> $HDD_LOG/$entry
+					echo /dev/null > $RAM_LOG/$entry
+				else
+					cp -rfup $RAM_LOG/$entry -T $HDD_LOG/ 2>&1 | $LOG_OUTPUT
+				fi
+			done
+		else
+			cp -rfup $RAM_LOG/ -T $HDD_LOG/ 2>&1 | $LOG_OUTPUT
+		fi
     fi
 }
 

--- a/log2ram.conf
+++ b/log2ram.conf
@@ -16,7 +16,7 @@ USE_RSYNC=false
 # Change it to false and you will have only a log if there is no place on RAM anymore.
 MAIL=true
 
-# This variable can be set to true if you would like to truncate logs in memory
-# is very helpful when your logs ram folder always full. This will attach current logs
-# to hdd logs and set inmemory logs size to 0
+# This variable can be set to true if you would like to truncate logs in memory.
+# It is very helpful when your logs ram folder is always full. This option will attach current logs
+# to your hdd logs and set inmemory logs size to 0.
 USE_PATCH=true

--- a/log2ram.conf
+++ b/log2ram.conf
@@ -15,3 +15,8 @@ USE_RSYNC=false
 # If there are some errors with available RAM space, a system mail will be send
 # Change it to false and you will have only a log if there is no place on RAM anymore.
 MAIL=true
+
+# This variable can be set to true if you would like to truncate logs in memory
+# is very helpful when your logs ram folder always full. This will attach current logs
+# to hdd logs and set inmemory logs size to 0
+USE_PATCH=true


### PR DESCRIPTION
Hello,
If I'm using log2ram, but with time its RAM Drive is getting full and on a long running machine and it does not work any more. I added option to truncate in memory logs and attach logs to the hdd.
Possible improvements:
 - added check if RAMLOG is e.g. 75% full and truncate logs
 - truncate more efficient?

Please TEST it!

I did tested it, but this was on my specific machine.

Regards,
Georgiy.