### PR TITLE
Make log2ram shutdown after journald has shutdown

### DIFF
--- a/log2ram.service
+++ b/log2ram.service
@@ -17,3 +17,4 @@ RemainAfterExit=yes
 
 [Install]
 WantedBy=sysinit.target
+RequiredBy=systemd-journald.service


### PR DESCRIPTION
#83 At system shutdown log2ram should wait until journald has shutdown before syncing back to disk, otherwise it will sync an unclosed journal log.