### PR TITLE
Remove /var/log if too big to install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,40 @@
 #!/usr/bin/env sh
+set -x
+. ./log2ram.conf
+
+isLogFolderSizeEnough () {
+    LOG_FOLDER="/var/log"
+
+    LOG_FOLDER_SIZE="$(sudo du -bs $RAM_LOG | awk '{print $1}')"
+    LOG2RAM_CONFIGURED_SIZE=$(literalSizeToNumbers $1)
+    if [ "$LOG_FOLDER_SIZE" -gt "$LOG2RAM_CONFIGURED_SIZE" ]; then
+        echo 1
+    else
+        echo 0
+    fi
+
+}
+
+literalSizeToNumbers() {
+    echo $(numfmt --from=iec $1)
+}
+
+assertSufficientSpace () {
+    ok=$(isLogFolderSizeEnough $SIZE)
+    if [ "$ok" -eq 1 ]; then
+        while true; do
+            read -p "$RAM_LOG is too big to continue. Would you like to delete it? [Y/n]: " yn
+            case $yn in
+                [Yy]* ) rm -rf $RAM_LOG; break;;
+                [Nn]* ) exit 1;;
+                * ) echo "Please answer yes or no.";;
+                esac
+        done
+    fi
+
+}
+
+assertSufficientSpace
 
 systemctl -q is-active log2ram  && { echo "ERROR: log2ram service is still running. Please run \"sudo service log2ram stop\" to stop it."; exit 1; }
 [ "$(id -u)" -eq 0 ] || { echo "You need to be ROOT (sudo can be used)"; exit 1; }

--- a/log2ram
+++ b/log2ram
@@ -2,9 +2,6 @@
 
 . /etc/log2ram.conf
 
-HDD_LOG=/var/hdd.log
-RAM_LOG=/var/log
-
 LOG_NAME="log2ram.log"
 LOG2RAM_LOG="${RAM_LOG}/${LOG_NAME}"
 LOG_OUTPUT="tee -a $LOG2RAM_LOG"

--- a/log2ram.conf
+++ b/log2ram.conf
@@ -31,3 +31,5 @@ COMP_ALG=lz4
 # Really a guestimate of a bit bigger than compression ratio whilst minimising 0.1% mem usage of disk size
 LOG_DISK_SIZE=100M
 
+HDD_LOG=/var/hdd.log
+RAM_LOG=/var/log


### PR DESCRIPTION
This offers support for Ubuntu 18.04 for RPi3B+ and solves https://github.com/azlux/log2ram/issues/86\#issuecomment-521208855 .