### PR TITLE
start service before syslog-ng service too

### DIFF
--- a/log2ram.service
+++ b/log2ram.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Log2Ram
 DefaultDependencies=no
-Before=basic.target rsyslog.service syslog.target systemd-journald.service sysinit.target shutdown.target zram-swap-conf.service apache2.service
+Before=basic.target rsyslog.service syslog-ng.service syslog.target systemd-journald.service sysinit.target shutdown.target zram-swap-conf.service apache2.service
 After=local-fs.target
 Conflicts=shutdown.target reboot.target halt.target
 RequiresMountsFor=/var/log /var/hdd.log


### PR DESCRIPTION
prevent the failed startup of the syslog-ng daemon, if it's been used instead of the default rsyslog.