### PR TITLE
root privileges required for apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ _____
 ### With APT (recommended)
     echo "deb http://packages.azlux.fr/debian/ buster main" | sudo tee /etc/apt/sources.list.d/azlux.list
     wget -qO - https://azlux.fr/repo.gpg.key | sudo apt-key add -
-    apt update
-    apt install log2ram
+    sudo apt update
+    sudo apt install log2ram
 
 ### Manually
     curl -Lo log2ram.tar.gz https://github.com/azlux/log2ram/archive/master.tar.gz
@@ -133,7 +133,7 @@ systemctl status log2ram
 (Because sometime we need it)
 ### With APT
 ```
-apt remove log2ram
+sudo apt remove log2ram
 ```
 You can use `--purge` to remove config files as well.
 


### PR DESCRIPTION
Need to use `sudo apt` if not root user. proceeding 2 lines already incorporate `sudo` commands so for consistency these lines should be `sudo` too.

Long time user of L2R but first time installing with apt.

bash commands in the install guide fail with permission denied error as apt is unable to lock files for update, likewise `apt install` and thus `apt remove` should also be `sudo` assuming the norm is a non-root user.

```
pi@raspberrypi:~ $ apt update
Reading package lists... Done
E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
E: Unable to lock directory /var/lib/apt/lists/
W: Problem unlinking the file /var/cache/apt/pkgcache.bin - RemoveCaches (13: Permission denied)
W: Problem unlinking the file /var/cache/apt/srcpkgcache.bin - RemoveCaches (13: Permission denied)
pi@raspberrypi:~ $ sudo apt update
Get:1 http://raspbian.raspberrypi.org/raspbian buster InRelease [15.0 kB]
Hit:2 http://archive.raspberrypi.org/debian buster InRelease                    
Hit:3 http://packages.azlux.fr/debian buster InRelease                          
Fetched 15.0 kB in 1s (12.0 kB/s)                          
Reading package lists... Done
Building dependency tree       
Reading state information... Done
All packages are up to date.
```