### PR TITLE
Restore RSYNC for backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ You need to stop log2ram (`service log2ram stop`) and start the [install](#insta
 
 ## Customize
 #### variables :
-In the file `/etc/log2ram.conf`, there are three variables:
+In the file `/etc/log2ram.conf`, there are five variables:
 
 - `SIZE`: defines the size the log folder will reserve into the RAM (default is 40M).
-- `MAIL`: Disables the error system mail if there is not enough place on RAM (if set to `false`)
-- `PATH_DISK`: activate log2ram for other path than default one. Paths should be separated with a `;`
-- `ZL2R`: Enable zram compatibility (`false` by default). Check the comment on the config file. See https://github.com/StuartIanNaylor/zram-swap-config to configure a zram space on your raspberry before enable this option.
+- `USE_RSYNC`: (commented out by default = `true`) use `cp` instead of `rsync` (if set to `false`).
+- `MAIL`: disables the error system mail if there is not enough place on RAM (if set to `false`).
+- `PATH_DISK`: activate log2ram for other path than default one. Paths should be separated with a `;`.
+- `ZL2R`: enable zram compatibility (`false` by default). Check the comment on the config file. See https://github.com/StuartIanNaylor/zram-swap-config to configure a zram space on your raspberry before enable this option.
 
 #### refresh time:
 By default Log2Ram writes to disk every day. If you think this is too much, you can run `systemctl edit log2ram-daily.timer` and add:

--- a/log2ram
+++ b/log2ram
@@ -7,7 +7,7 @@ if [ -z "$PATH_DISK" ]; then
 fi
 
 LOG_NAME='log2ram.log'
-
+NO_RSYNC=${USE_RSYNC#true}
 
 isSafe () {
     [ -d "$HDD_LOG" ] || echo "ERROR: $HDD_LOG/ doesn't exist! Can't sync."
@@ -22,7 +22,7 @@ remountOriginal() {
 syncToDisk () {
     isSafe
 
-    if [ -x "$(command -v rsync)" ]; then
+    if [ -z "${NO_RSYNC}" -a -x "$(command -v rsync)" ]; then
         rsync -aXv --inplace --no-whole-file --delete-after "$RAM_LOG"/ "$HDD_LOG"/ 2>&1 | tee -a "$LOG2RAM_LOG"
     else
         cp -rfup "$RAM_LOG"/ -T "$HDD_LOG"/ 2>&1 | tee -a "$LOG2RAM_LOG"
@@ -47,7 +47,7 @@ syncFromDisk () {
         exit 1
     fi
 
-    if [ -x "$(command -v rsync)" ]; then
+    if [ -z "${NO_RSYNC}" -a -x "$(command -v rsync)" ]; then
         rsync -aXv --inplace --no-whole-file --delete-after "$HDD_LOG"/ "$RAM_LOG"/ 2>&1 | tee -a "$LOG2RAM_LOG"
     else
         cp -rfup "$HDD_LOG"/ -T "$RAM_LOG"/ 2>&1 | tee -a "$LOG2RAM_LOG"

--- a/log2ram.conf
+++ b/log2ram.conf
@@ -7,6 +7,15 @@
 # You will need to increase it if you have a server and a lot of log for example.
 SIZE=40M
 
+# Select the log syncing method between the log directory on disk and in the RAM.
+# The variable may be uncommented out, setting it to false, if "cp" is preferred over "rsync".
+# Pre 1.6.1 the config default was to use "cp", unless USE_RSYNC was explicitly set to true.
+# Post 1.6.1 the parameter was briefly removed and "rsync" became the default whenever
+# installed. Currently, this option needs to be unset or set to true for "rsync" to run,
+# with "cp" available for fallback when "rsync" is missing.
+# In all other cases, setting USE_RSYNC to anything other than true will default to "cp".
+#USE_RSYNC=false
+
 # If there are some errors with available RAM space, a system mail will be send
 # Change it to false and you will have only a log if there is no place on RAM anymore.
 MAIL=true

--- a/log2ram.conf
+++ b/log2ram.conf
@@ -9,9 +9,7 @@ SIZE=40M
 
 # Select the log syncing method between the log directory on disk and in the RAM.
 # The variable may be uncommented out, setting it to false, if "cp" is preferred over "rsync".
-# Pre 1.6.1 the config default was to use "cp", unless USE_RSYNC was explicitly set to true.
-# Post 1.6.1 the parameter was briefly removed and "rsync" became the default whenever
-# installed. Currently, this option needs to be unset or set to true for "rsync" to run,
+# Currently, this option needs to be unset or set to true for "rsync" to run,
 # with "cp" available for fallback when "rsync" is missing.
 # In all other cases, setting USE_RSYNC to anything other than true will default to "cp".
 #USE_RSYNC=false


### PR DESCRIPTION
This PR restores the ability to use `cp` instead of `rsync` for syncing files between the disk and the RAM. The parameter `USE_RSYNC` that controlled whether `rsync` is used was removed in 1.6.1.

Any parameter changes need to respect the former config default of `USE_RSYNC=false`. Many users won't knowingly agree to configuration file changes that remove a parameter that gave them a greater set of choices.

The restored parameter is intentionally commented out, respecting the removal of the parameter in post 1.6.1 `log2ram.conf` that defaulted to `rsync` for file transfers when installed. The default from pre 1.6.1 `log2ram.conf`, that is `USE_RSYNC=false`, is honoured.

Now `rsync` runs whenever `USE_RSYNC` is unset or missing (post 1.6.1 default in `log2ram.conf`) or set to true (case sensitive). `cp` is run for all other cases: when `USE_RSYNC` set to false (pre 1.6.1 default) or anything else, as well as when `rsync` isn't installed.