### PR TITLE
Check to see if conf file already exists before installing it.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ install -m 644 log2ram.service /etc/systemd/system/log2ram.service
 install -m 644 log2ram-daily.service /etc/systemd/system/log2ram-daily.service
 install -m 644 log2ram-daily.timer /etc/systemd/system/log2ram-daily.timer
 install -m 755 log2ram /usr/local/bin/log2ram
-if [ ! -f filename ]; then
+if [ ! -f /etc/log2ram.conf ]; then
 	install -m 644 log2ram.conf /etc/log2ram.conf
 fi
 install -m 644 uninstall.sh /usr/local/bin/uninstall-log2ram.sh

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,9 @@ install -m 644 log2ram.service /etc/systemd/system/log2ram.service
 install -m 644 log2ram-daily.service /etc/systemd/system/log2ram-daily.service
 install -m 644 log2ram-daily.timer /etc/systemd/system/log2ram-daily.timer
 install -m 755 log2ram /usr/local/bin/log2ram
-install -m 644 log2ram.conf /etc/log2ram.conf
+if [ ! -f filename ]; then
+	install -m 644 log2ram.conf /etc/log2ram.conf
+fi
 install -m 644 uninstall.sh /usr/local/bin/uninstall-log2ram.sh
 systemctl enable log2ram.service log2ram-daily.timer
 


### PR DESCRIPTION
We have an auto-configuration process that preps for `log2ram` by creating its `.conf` file before installation (sets the size to 100M for instance). Currently, the installation of Log2Ram blows this configuration away and installs the default configuration, which then fails to mount on reboot due to its small size. This adds a simple check before installing the `log2ram.conf` file.