### PR TITLE
 Systemd Sandboxing to log2ram-daily.service & log2ram.service. 

### DIFF
--- a/log2ram-daily.service
+++ b/log2ram-daily.service
@@ -4,3 +4,5 @@ After=log2ram.service
 
 [Service]
 ExecStart=/bin/systemctl reload log2ram.service
+
+## insert sandboxing here ##

--- a/log2ram-daily.service
+++ b/log2ram-daily.service
@@ -5,4 +5,19 @@ After=log2ram.service
 [Service]
 ExecStart=/bin/systemctl reload log2ram.service
 
-## insert sandboxing here ##
+# Sandboxing
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPriviliges=true
+PrivateDevices=true
+PrivateNetwork=true 
+  #May affect "Mail" in log2ram.conf.
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+RestrictSUIDSGID=true
+ProtectSystem=strict
+ProtectHome=true 

--- a/log2ram.service
+++ b/log2ram.service
@@ -15,12 +15,12 @@ ExecReload= /usr/local/bin/log2ram write
 TimeoutStartSec=120
 RemainAfterExit=yes
 
-#SANDBOXING# -- NEEDS TESTING
+#SANDBOXING# -- partly tested
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPriviliges=true
-#PrivateDevices=
-#PrivateNetwork=true 
+PrivateDevices=true
+PrivateNetwork=true 
   #Will likely break "MAIL" in log2ram.config if does not point to localhost / disabled
 ProtectClock=true
 ProtectControlGroups=true
@@ -29,8 +29,8 @@ ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
 RestrictSUIDSGID=true
-ProtectSystem=full
-  # ALT: ProtectSystem=true # if-and-only-if needs /etc, but can whitelist dir prn 
+ProtectSystem=true
+  # ALT: ProtectSystem=full # needs rw whitelisting for /var/hdd.log/ 
 ProtectHome=true 
   #will likely break situations wherein configured to also copy logs from $HOME. 
   #can probably fix with systemctl edit to whitelist relevant dirs 

--- a/log2ram.service
+++ b/log2ram.service
@@ -15,13 +15,13 @@ ExecReload= /usr/local/bin/log2ram write
 TimeoutStartSec=120
 RemainAfterExit=yes
 
-# SANDBOXING
+# Sandboxing
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPriviliges=true
 PrivateDevices=true
 PrivateNetwork=true 
-  #Will likely break "MAIL" in log2ram.config if does not point to localhost or is unused. 
+  #May break "MAIL" in log2ram.conf if it points to non-local web address. 
 ProtectClock=true
 ProtectControlGroups=true
 ProtectHostname=true
@@ -32,8 +32,8 @@ RestrictSUIDSGID=true
 ProtectSystem=true
   # ALT: ProtectSystem=full # needs rw whitelisting for /var/hdd.log/ 
 ProtectHome=true 
-  #will likely break situations wherein configured to also copy logs from $HOME. 
-  #can probably fix with systemctl edit to whitelist relevant dirs 
+  #may cause breakage in situations wherein user has configured log2ram to also copy logs from $HOME. 
+  #can probably fix with systemctl edit to whitelist relevant dirs. See: ReadWritePaths=
 
 [Install]
 WantedBy=sysinit.target

--- a/log2ram.service
+++ b/log2ram.service
@@ -23,7 +23,7 @@ NoNewPriviliges=true
 #PrivateNetwork=true 
   #Will likely break "MAIL" in log2ram.config if does not point to localhost / disabled
 ProtectClock=true
-ProtectControlGroups=
+ProtectControlGroups=true
 ProtectHostname=true
 ProtectKernelLogs=true
 ProtectKernelModules=true

--- a/log2ram.service
+++ b/log2ram.service
@@ -15,13 +15,13 @@ ExecReload= /usr/local/bin/log2ram write
 TimeoutStartSec=120
 RemainAfterExit=yes
 
-#SANDBOXING# -- partly tested
+# SANDBOXING
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPriviliges=true
 PrivateDevices=true
 PrivateNetwork=true 
-  #Will likely break "MAIL" in log2ram.config if does not point to localhost / disabled
+  #Will likely break "MAIL" in log2ram.config if does not point to localhost or is unused. 
 ProtectClock=true
 ProtectControlGroups=true
 ProtectHostname=true
@@ -34,9 +34,6 @@ ProtectSystem=true
 ProtectHome=true 
   #will likely break situations wherein configured to also copy logs from $HOME. 
   #can probably fix with systemctl edit to whitelist relevant dirs 
-
-
-
 
 [Install]
 WantedBy=sysinit.target

--- a/log2ram.service
+++ b/log2ram.service
@@ -15,5 +15,28 @@ ExecReload= /usr/local/bin/log2ram write
 TimeoutStartSec=120
 RemainAfterExit=yes
 
+#SANDBOXING# -- NEEDS TESTING
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPriviliges=true
+#PrivateDevices=
+#PrivateNetwork=true 
+  #Will likely break "MAIL" in log2ram.config if does not point to localhost / disabled
+ProtectClock=true
+ProtectControlGroups=
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+RestrictSUIDSGID=true
+ProtectSystem=full
+  # ALT: ProtectSystem=true # if-and-only-if needs /etc, but can whitelist dir prn 
+ProtectHome=true 
+  #will likely break situations wherein configured to also copy logs from $HOME. 
+  #can probably fix with systemctl edit to whitelist relevant dirs 
+
+
+
+
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
I have added some common Systemd sandboxing options. The additions seek to move the services toward a posture of securer defaults. It is best practice to implement such restrictions to long running services. Furthermore, despite my personal aversion to reading them, logs are a critical element of system security. 

My pull request changes the output of:
```sh
systemd-analyze security log2ram.service && systemd-analyze security log2ram-daily.service
```
from ~9 (unsafe) to ~ 6 (medium). 

Some added options have comments below them regarding possible lost functionality. It is up to the developer to determine whether to include those specific lines, i.e. whether to maximize user friendliness or not. If those lines were removed, the end-user could simply add it themselves if they wanted to, so it's not that important anyways.

For background context on Systemd-Sandboxing, see: [link](https://www.freedesktop.org/software/systemd/man/systemd.exec.html)

I will accept chin scritchies as a token of appreciation. 

Friendly meows, 
TubbyCat