### PR TITLE
Added more output on start failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ If the `/var/log/journal` is very large, then there are a lot of system logs. De
 SystemMaxUse=20M
 ```
 
+**Or** the more radical version of directly flushing the journal to a size that matches log2ram size imediately _(Be aware that this flish flush the systemd journal logs imediately to the given size!)_
+
+```bash
+journalctl --vacuum-size=32M
+```
+
 This should be set to a value smaller than the size of the RAM volume; for example, half of it could be fine. Then, apply the new setting:
 
 ```bash

--- a/log2ram
+++ b/log2ram
@@ -63,6 +63,7 @@ sync_from_disk() {
 
     if [ -n "$(du -sh -t "$TP_SIZE" "$HDD_LOG"/ | cut -f1)" ]; then
         echo "ERROR: RAM disk for \"$HDD_LOG/\" too small. Can't sync."
+        echo -e "File(s) causing issues\n: $(du -sh -t "$TP_SIZE" "$HDD_LOG"/*)"
         umount -l "$RAM_LOG"/
         umount -l "$HDD_LOG"/
         if [ "$MAIL" = true ]; then


### PR DESCRIPTION
As I encountered an error where I tried to start log2Ram on a new system I added a more helpful output to the huge file failure in the syncFromDisk function.
And also an example command to flush the systemd journal as this was the culprit in my case.
May be this helps someone that, as I did, stumble for a few minutes while searching for the cause. (As one might be able to determine, it was the systemd journal growing to a huge size while containing nothing usefull at all on a new, empty, and unused system...)