### PR TITLE
genericize apt install instuctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ _____
 6. [Uninstallation](#uninstallation-)
 
 ## Installation
-### Via APT (recommended)
+### Via APT (recommended) (genericized)
 
 ```bash
-echo "deb [signed-by=/usr/share/keyrings/azlux-archive-keyring.gpg] http://packages.azlux.fr/debian/ bookworm main" | sudo tee /etc/apt/sources.list.d/azlux.list
+echo "deb [signed-by=/usr/share/keyrings/azlux-archive-keyring.gpg] http://packages.azlux.fr/debian/ $(bash -c '. /etc/os-release; echo ${VERSION_CODENAME}') main" | sudo tee /etc/apt/sources.list.d/azlux.list
 sudo wget -O /usr/share/keyrings/azlux-archive-keyring.gpg  https://azlux.fr/repo.gpg
 sudo apt update
 sudo apt install log2ram


### PR DESCRIPTION
Make the APT install instuction easier to copy paste without needing edits for different releases, by using VERSION_CODENAME  from os-release, on all debian variants.

```
samveen@z2w:~/workspace/log2ram $ bash -c '. /etc/os-release; echo ${VERSION_CODENAME}'
bullseye
```
