### PR TITLE
Handle sparse files correctly

### DIFF
--- a/log2ram
+++ b/log2ram
@@ -44,10 +44,10 @@ sync_to_disk() {
     fi
 
     if [ -z "${NO_RSYNC}" ] && [ -x "$(command -v rsync)" ]; then
-        rsync -aXv --inplace --no-whole-file --delete-after "${optional_params[@]}" "$RAM_LOG"/ "$HDD_LOG"/ 2>&1 |
+        rsync -aXv --sparse --inplace --no-whole-file --delete-after "${optional_params[@]}" "$RAM_LOG"/ "$HDD_LOG"/ 2>&1 |
             tee -a "$LOG2RAM_LOG"
     else
-        cp -rfup "$RAM_LOG"/ -T "$HDD_LOG"/ 2>&1 | tee -a "$LOG2RAM_LOG"
+        cp -rfup --sparse=always "$RAM_LOG"/ -T "$HDD_LOG"/ 2>&1 | tee -a "$LOG2RAM_LOG"
     fi
 }
 
@@ -73,9 +73,9 @@ sync_from_disk() {
     fi
 
     if [ -z "${NO_RSYNC}" ] && [ -x "$(command -v rsync)" ]; then
-        rsync -aXv --inplace --no-whole-file --delete-after "$HDD_LOG"/ "$RAM_LOG"/ 2>&1 | tee -a "$LOG2RAM_LOG"
+        rsync -aXv --sparse --inplace --no-whole-file --delete-after "$HDD_LOG"/ "$RAM_LOG"/ 2>&1 | tee -a "$LOG2RAM_LOG"
     else
-        cp -rfup "$HDD_LOG"/ -T "$RAM_LOG"/ 2>&1 | tee -a "$LOG2RAM_LOG"
+        cp -rfup --sparse=always "$HDD_LOG"/ -T "$RAM_LOG"/ 2>&1 | tee -a "$LOG2RAM_LOG"
     fi
 
 }


### PR DESCRIPTION
See issue  #138.
Right now, big sparse files (e.g. log files with big "holes" in them, like `/var/log/lastlog` when users/groups with large ids exist) take up much space when written to disk, because they are written as regular files, not sparse files.
`rsync` supports `--sparse` in combination with `--inplace` [since version 3.1.3](https://github.com/WayneD/rsync/commit/f3873b3d88b61167b106e7b9227a20147f8f6197) which was published [early 2018](https://github.com/WayneD/rsync/releases/tag/v3.1.3).