### PR TITLE
Ansible yaml update

### DIFF
--- a/ansible_playbook/install_log2ram.yml
+++ b/ansible_playbook/install_log2ram.yml
@@ -16,14 +16,14 @@
     log2ram_keyring: /usr/share/keyrings/azlux-archive-keyring.gpg
     log2ram_apt_repository: "deb [signed-by={{ log2ram_keyring }}] {{ log2ram_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
 
-    log2ram_size: 40M
+    log2ram_size: 128M
     log2ram_use_rsync: true
     log2ram_notification: true
     log2ram_notification_command: 'mail -s "Log2Ram Error on $HOSTNAME"'
     log2ram_path_disk: /var/log
-    log2ram_use_z2lr: true
+    log2ram_use_z2lr: false
     log2ram_comp_alg: lz4
-    log2ram_log_disk_size: 100M
+    log2ram_log_disk_size: 256M
 
 
   tasks:

--- a/ansible_playbook/install_log2ram.yml
+++ b/ansible_playbook/install_log2ram.yml
@@ -18,7 +18,8 @@
 
     log2ram_size: 40M
     log2ram_use_rsync: true
-    log2ram_mail: true
+    log2ram_notification: true
+    log2ram_notification_command: 'mail -s "Log2Ram Error on $HOSTNAME"'
     log2ram_path_disk: /var/log
     log2ram_use_z2lr: true
     log2ram_comp_alg: lz4
@@ -62,7 +63,8 @@
       loop:
         - {regexp: '^SIZE=(.*)$', line: 'SIZE={{ log2ram_size }}'}
         - {regexp: 'USE_RSYNC=(.*)$', line: 'USE_RSYNC={{ log2ram_use_rsync }}'}
-        - {regexp: '^MAIL=(.*)$', line: 'MAIL={{ log2ram_mail }}'}
+        - {regexp: '^NOTIFICATION=(.*)$', line: 'NOTIFICATION={{ log2ram_notification }}'}
+        - {regexp: '^NOTIFICATION_COMMAND=(.*)$', line: 'NOTIFICATION_COMMAND={{ log2ram_notification_command }}'}
         - {regexp: '^PATH_DISK=(.*)$', line: 'PATH_DISK="{{ log2ram_path_disk }}"'}
         - {regexp: '^ZL2R=(.*)$', line: 'ZL2R={{ log2ram_use_z2lr|lower }}'}
         - {regexp: '^COMP_ALG=(.*)$', line: 'COMP_ALG={{ log2ram_comp_alg }}'}

--- a/ansible_playbook/install_log2ram.yml
+++ b/ansible_playbook/install_log2ram.yml
@@ -32,6 +32,10 @@
         name: rsync
       when: log2ram_use_rsync
 
+    - name: Install GnuPG
+      apt:
+        name: gnupg
+
     - name: Add gpg key
       shell: 
         cmd: >


### PR DESCRIPTION
# Ansible Playbook Update

## Key Changes

###  Auto-install prerequisite

- Added an Ansible task to install the prerequisite apt package 'gnupg', (Required by task: 'Add gpg key').

### Aligning config defaults

- Matched the Ansible playbook settings with the Log2Ram config defaults to ensure consistency and predictability. 

### Corrected Notification Setting

- Updated the playbook to use `NOTIFICATION=` instead of the incorrect `MAIL=` parameter. 

### Support for Customizable Notification Commands

- Added the `NOTIFICATION_COMMAND=` setting to allow users to specify custom commands for notifications. 

