### PR TITLE
fix mail notifications

### DIFF
--- a/log2ram
+++ b/log2ram
@@ -69,7 +69,7 @@ sync_from_disk() {
         umount -l "$RAM_LOG"/
         umount -l "$HDD_LOG"/
         if [ "$NOTIFICATION" = true ]; then
-            echo "LOG2RAM : No place on RAM for \"$HDD_LOG/\" anymore, fallback on the disk" | $NOTIFICATION_COMMAND
+            echo "LOG2RAM : No place on RAM for \"$HDD_LOG/\" anymore, fallback on the disk" | eval $NOTIFICATION_COMMAND
         fi
         exit 1
     fi


### PR DESCRIPTION
It looks like $NOTIFICATION_COMMAND is not handled as a command but as a simple string, in journal log i would see an invalid command error like: 
`Jan 06 15:31:57 mini log2ram[337874]: /usr/local/bin/log2ram: line 73: mail -s "Log2Ram Error on mini" root: No such file or directory`

adding eval fixes this