### PR TITLE
Add a .gitattributes file enforcing LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
On Windows autocrlf is true by default. This makes sure we use LF everywhere.

/CC @azlux 